### PR TITLE
refactor(market_candle): change fetch method return type to Iterator

### DIFF
--- a/src/pricelab_retriever/adapter/outbound/alpha_vantage/adapter.py
+++ b/src/pricelab_retriever/adapter/outbound/alpha_vantage/adapter.py
@@ -1,4 +1,4 @@
-from typing import Dict, Sequence
+from typing import Dict, Sequence, Iterator
 
 from pricelab_core.domain.model.candles.candle import Candle
 from pricelab_core.infrastructure.http.port.resilient_http_client import ResilientHttpClient
@@ -14,10 +14,9 @@ class AlphaVantageMarketCandle:
         self._settings = settings
         self._mapper = mapper
 
-    async def fetch(self, query: MarketCandleQuery) -> Sequence[Candle]:
+    async def fetch(self, query: MarketCandleQuery) -> Iterator[Candle]:
         raw: dict = await self._client.get(self._settings.operation.endpoint, params=self._get_client_params(query))
-        candles: Sequence[Candle] = tuple(self._mapper.map(raw))
-        return candles
+        return self._mapper.map(raw)
 
     def _get_client_params(self, query: MarketCandleQuery) -> Dict[str, str]:
         params = {

--- a/src/pricelab_retriever/application/port/outbound/market_candle.py
+++ b/src/pricelab_retriever/application/port/outbound/market_candle.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Protocol, Sequence, Optional
+from typing import Protocol, Optional, Iterator
 
 from pricelab_core.domain.model.candles.candle import Candle
 
@@ -11,4 +11,4 @@ class MarketCandleQuery:
 
 
 class MarketCandle(Protocol):
-    async def fetch(self, query: MarketCandleQuery) -> Sequence[Candle]: ...
+    async def fetch(self, query: MarketCandleQuery) -> Iterator[Candle]: ...

--- a/src/pricelab_retriever/application/use_case/stock_candle_use_case.py
+++ b/src/pricelab_retriever/application/use_case/stock_candle_use_case.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Sequence, Iterator
 from pricelab_core.domain.model.candles.candle import Candle
 
 from pricelab_retriever.application.port.inbound.stock_candle import StockCandleQuery
@@ -11,4 +11,5 @@ class StockCandleUseCase:
 
     async def __call__(self, query: StockCandleQuery) -> Sequence[Candle]:
         _query = MarketCandleQuery(symbol=query.symbol, interval=query.interval)
-        return await self._candle_adapter.fetch(_query)
+        candles: Iterator[Candle] = await self._candle_adapter.fetch(_query)
+        return tuple(candles)


### PR DESCRIPTION
- Update fetch method in AlphaVantage adapter to return Iterator[Candle] instead of Sequence[Candle]
- Modify MarketCandle protocol to reflect the return type change to Iterator[Candle]
- Adjust stock candle use case to collect Iterator[Candle] into a tuple before returning
- Import Iterator type in relevant modules for type hinting consistency